### PR TITLE
ci: add renv library cache to speed up PR checks

### DIFF
--- a/.github/workflows/r-check.yml
+++ b/.github/workflows/r-check.yml
@@ -1,0 +1,53 @@
+name: R Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  source-check:
+    runs-on: ubuntu-latest
+    container: rocker/r-ver:4.4
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          apt-get update && apt-get install -y --no-install-recommends \
+            libwebp-dev \
+            libcurl4-openssl-dev \
+            libuv1-dev
+
+      - name: Cache renv library
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/R/renv
+          key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-renv-
+
+      - name: Install renv and restore dependencies
+        run: |
+          if (!requireNamespace("renv", quietly = TRUE)) install.packages("renv")
+          renv::restore()
+        shell: Rscript {0}
+
+      - name: Smoke test — source all R files
+        run: |
+          files <- list.files('.', full.names = TRUE, recursive = FALSE)
+          files <- files[endsWith(files, '.R')]
+          files <- files[!basename(files) %in% 'startApp.R']
+          for (f in files) {
+            cat('Loading:', f, '\n')
+            source(f)
+          }
+          cat('All R files loaded successfully.\n')
+        shell: Rscript {0}


### PR DESCRIPTION
## Problem

PR checks currently take 1-2 minutes because `renv::restore()` downloads and installs all 133 R packages from scratch on every run.

## Solution

Add `actions/cache@v4` to cache the renv library between CI runs, following the [official renv CI guide](https://rstudio.github.io/renv/articles/ci.html).

### What changed

- Added a cache step that stores `~/.cache/R/renv`
- Cache key: `${ runner.os }-renv-${ hashFiles(``**/renv.lock``) }`
- Restore keys provide partial cache hits when lockfile changes
- Changed `renv` install to only install if not already present

### Expected impact

- **First run after lockfile change:** full restore (same as now)
- **Subsequent runs:** cached restore — only downloads changed packages
- **Typical PR check time:** ~10-30s vs 1-2min

## Testing

The workflow YAML was verified for correct syntax. The cache setup follows the recommended pattern from renv's documentation.