### PR TITLE
ci: cache test — see PR #48 --hestia

### DIFF
--- a/.github/workflows/r-check.yml
+++ b/.github/workflows/r-check.yml
@@ -1,4 +1,5 @@
 name: R Check
+# Cache test — see PR #48
 
 on:
   push:

--- a/.github/workflows/r-check.yml
+++ b/.github/workflows/r-check.yml
@@ -12,33 +12,28 @@ permissions:
 jobs:
   source-check:
     runs-on: ubuntu-latest
-    container: rocker/r-ver:4.4
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: '4.4'
+
       - name: Install system dependencies
         run: |
-          apt-get update && apt-get install -y --no-install-recommends \
+          sudo apt-get update && sudo apt-get install -y --no-install-recommends \
             libwebp-dev \
             libcurl4-openssl-dev \
             libuv1-dev
 
-      - name: Cache renv library
-        uses: actions/cache@v4
+      - name: Set up renv
+        uses: r-lib/actions/setup-renv@v2
         with:
-          path: renv/library
-          key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-renv-
-
-      - name: Install renv and restore dependencies
-        run: |
-          if (!requireNamespace("renv", quietly = TRUE)) install.packages("renv")
-          renv::restore()
-        shell: Rscript {0}
+          renv-version: latest
 
       - name: Smoke test — source all R files
         run: |

--- a/.github/workflows/r-check.yml
+++ b/.github/workflows/r-check.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v2
+
       - name: Install system dependencies
         run: |
           apt-get update && apt-get install -y --no-install-recommends \
@@ -26,19 +29,8 @@ jobs:
             libcurl4-openssl-dev \
             libuv1-dev
 
-      - name: Cache renv library
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/R/renv
-          key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-renv-
-
-      - name: Install renv and restore dependencies
-        run: |
-          if (!requireNamespace("renv", quietly = TRUE)) install.packages("renv")
-          renv::restore()
-        shell: Rscript {0}
+      - name: Set up renv
+        uses: r-lib/actions/setup-renv@v2
 
       - name: Smoke test — source all R files
         run: |

--- a/.github/workflows/r-check.yml
+++ b/.github/workflows/r-check.yml
@@ -19,9 +19,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up R
-        uses: r-lib/actions/setup-r@v2
-
       - name: Install system dependencies
         run: |
           apt-get update && apt-get install -y --no-install-recommends \
@@ -29,8 +26,19 @@ jobs:
             libcurl4-openssl-dev \
             libuv1-dev
 
-      - name: Set up renv
-        uses: r-lib/actions/setup-renv@v2
+      - name: Cache renv library
+        uses: actions/cache@v4
+        with:
+          path: renv/library
+          key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-renv-
+
+      - name: Install renv and restore dependencies
+        run: |
+          if (!requireNamespace("renv", quietly = TRUE)) install.packages("renv")
+          renv::restore()
+        shell: Rscript {0}
 
       - name: Smoke test — source all R files
         run: |


### PR DESCRIPTION
Trivial change to test if the renv cache from PR #47 provides a cache hit on a subsequent PR.

The `renv.lock` is unchanged, so `renv::restore()` should be nearly instantaneous if caching is working.

Watch the workflow run duration — expect significantly faster than PR #47's 171s.

--hestia