### PR TITLE
ci: cache hit test — see PR #49 --hestia

### DIFF
--- a/.github/workflows/r-check.yml
+++ b/.github/workflows/r-check.yml
@@ -1,5 +1,4 @@
 name: R Check
-# Cache test — see PR #48
 
 on:
   push:
@@ -9,6 +8,9 @@ on:
 
 permissions:
   contents: read
+
+env:
+  RENV_PATHS_ROOT: ~/.cache/R/renv
 
 jobs:
   source-check:
@@ -31,10 +33,19 @@ jobs:
             libcurl4-openssl-dev \
             libuv1-dev
 
-      - name: Set up renv
-        uses: r-lib/actions/setup-renv@v2
+      - name: Cache renv library
+        uses: actions/cache@v4
         with:
-          renv-version: latest
+          path: ${{ env.RENV_PATHS_ROOT }}
+          key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-renv-
+
+      - name: Restore packages
+        run: |
+          if (!requireNamespace("renv", quietly = TRUE)) install.packages("renv")
+          renv::restore()
+        shell: Rscript {0}
 
       - name: Smoke test — source all R files
         run: |

--- a/.github/workflows/r-check.yml
+++ b/.github/workflows/r-check.yml
@@ -1,4 +1,5 @@
 name: R Check
+# Cache test — see PR #48
 
 on:
   push:

--- a/.github/workflows/r-check.yml
+++ b/.github/workflows/r-check.yml
@@ -12,33 +12,28 @@ permissions:
 jobs:
   source-check:
     runs-on: ubuntu-latest
-    container: rocker/r-ver:4.4
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: '4.4'
+
       - name: Install system dependencies
         run: |
-          apt-get update && apt-get install -y --no-install-recommends \
+          sudo apt-get update && sudo apt-get install -y --no-install-recommends \
             libwebp-dev \
             libcurl4-openssl-dev \
             libuv1-dev
 
-      - name: Cache renv library
-        uses: actions/cache@v4
+      - name: Set up renv
+        uses: r-lib/actions/setup-renv@v2
         with:
-          path: renv/library
-          key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-renv-
-
-      - name: Install renv and restore dependencies
-        run: |
-          if (!requireNamespace("renv", quietly = TRUE)) install.packages("renv")
-          renv::restore()
-        shell: Rscript {0}
+          renv-version: latest
 
       - name: Smoke test — source all R files
         run: |

--- a/.github/workflows/r-check.yml
+++ b/.github/workflows/r-check.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v2
+
       - name: Install system dependencies
         run: |
           apt-get update && apt-get install -y --no-install-recommends \
@@ -26,19 +29,8 @@ jobs:
             libcurl4-openssl-dev \
             libuv1-dev
 
-      - name: Cache renv library
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/R/renv
-          key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-renv-
-
-      - name: Install renv and restore dependencies
-        run: |
-          if (!requireNamespace("renv", quietly = TRUE)) install.packages("renv")
-          renv::restore()
-        shell: Rscript {0}
+      - name: Set up renv
+        uses: r-lib/actions/setup-renv@v2
 
       - name: Smoke test — source all R files
         run: |

--- a/.github/workflows/r-check.yml
+++ b/.github/workflows/r-check.yml
@@ -19,9 +19,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up R
-        uses: r-lib/actions/setup-r@v2
-
       - name: Install system dependencies
         run: |
           apt-get update && apt-get install -y --no-install-recommends \
@@ -29,8 +26,19 @@ jobs:
             libcurl4-openssl-dev \
             libuv1-dev
 
-      - name: Set up renv
-        uses: r-lib/actions/setup-renv@v2
+      - name: Cache renv library
+        uses: actions/cache@v4
+        with:
+          path: renv/library
+          key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-renv-
+
+      - name: Install renv and restore dependencies
+        run: |
+          if (!requireNamespace("renv", quietly = TRUE)) install.packages("renv")
+          renv::restore()
+        shell: Rscript {0}
 
       - name: Smoke test — source all R files
         run: |


### PR DESCRIPTION
## Cache hit verification

This is a trivial change to test if the renv cache from PR #49 persists.

### Expected:
- **PR #49 (cache miss, first run):** 139s total, 75s for `Restore packages`
- **This PR (cache hit):** should complete in seconds

### Reference:
- PR #49: https://github.com/zenonsommers/rcbc_shiny/pull/49
- Cache key: `Linux-renv-{hash of renv.lock}`
- Cache path: `~/.cache/R/renv` (set via `RENV_PATHS_ROOT`)
