### PR TITLE
fix: anchor LCS pattern matching to start/end of column names --hestia

### DIFF
--- a/cpo_stv.R
+++ b/cpo_stv.R
@@ -73,10 +73,19 @@ removeQuestion <- function(df) {
   
   # now actually remove both LCS, then return the updated dataframe
   # <-- CHANGE: Escape special regex characters in the found strings
-  colnames(df) <- cols %>%
-    str_replace(stringr::str_escape(LCS1), "") %>%
-    str_replace(stringr::str_escape(LCS2), "") %>%
-    str_trim() # Use str_trim for a cleaner result than replacing periods
+  
+  # Only remove substrings if they were actually found (non-empty)
+  new_names <- cols
+  if (nzchar(LCS1)) {
+    # Remove the common prefix (anchored at start with ^)
+    new_names <- str_replace(new_names, paste0("^", stringr::str_escape(LCS1)), "")
+  }
+  if (nzchar(LCS2)) {
+    # Remove the common suffix (anchored at end with $)
+    new_names <- str_replace(new_names, paste0(stringr::str_escape(LCS2), "$"), "")
+  }
+  
+  colnames(df) <- str_trim(new_names) # Use str_trim for a cleaner result than replacing periods
   
   return(df)
 }


### PR DESCRIPTION
## Summary

This PR fixes the `removeQuestion()` function in `cpo_stv.R` that was causing CSV import failures when column names had no common prefix or suffix.

### Bug Description

When parsing CSV files where candidate names share no common prefix or suffix (e.g., "Alice", "Bob", "Charlie"), the function would:

1. Leave `LCS1` and `LCS2` as empty strings `""`
2. Pass these empty strings to `str_replace()`, which throws:
   `"pattern can't be the empty string"`

### Additional Issue

Even when a common substring WAS found, the original `str_replace()` was **unanchored**, meaning it would remove the first occurrence of the substring **anywhere** in the candidate name — even if it appeared mid-string. This caused incorrect renaming of candidate names.

### The Fix

1. **Guard against empty patterns** — Only call `str_replace()` when `nzchar(LCS1)` or `nzchar(LCS2)` is true (i.e., the substring was actually found)

2. **Anchor patterns to string boundaries**:
   - `LCS1` (common prefix) is now anchored to the **start** with `^`
   - `LCS2` (common suffix) is now anchored to the **end** with `$`
   
   This ensures only true prefix/suffix matches are stripped, not mid-string occurrences.

### Testing

- Tested against the sample CSV from [issue #41](https://github.com/zenonsommers/rcbc_shiny/issues/41) which has no common prefix/suffix
- Verified the old logic raises an error on this input
- Verified the new logic correctly handles it
- Verified prefix/suffix stripping still works for Google Forms-style headers

Closes #41
