### PR TITLE
fix: coerce relevant_candidates and transfer_eligible to character in compare_matchup

### DIFF
--- a/Sample Data/rcbc-cycle-14/ballot_23b76b20-9062-46f8-a565-e22ef28dd199.json
+++ b/Sample Data/rcbc-cycle-14/ballot_23b76b20-9062-46f8-a565-e22ef28dd199.json
@@ -1,0 +1,1 @@
+{"The Novice’s Tale - 240":1,"The Weary Blues - 128":4,"The Prestige - 404":3,"Anna Karenina - 864":5,"And Then There Were None - 272":2,"The Invincible - 200":6}

--- a/Sample Data/rcbc-cycle-14/ballot_52c98bb1-2b6d-44ee-ba8e-eca52af7dfb1.json
+++ b/Sample Data/rcbc-cycle-14/ballot_52c98bb1-2b6d-44ee-ba8e-eca52af7dfb1.json
@@ -1,0 +1,1 @@
+{"The Novice’s Tale - 240":3,"The Weary Blues - 128":6,"The Prestige - 404":4,"Anna Karenina - 864":1,"And Then There Were None - 272":5,"The Invincible - 200":2}

--- a/Sample Data/rcbc-cycle-14/ballot_5dd8867c-ab05-446f-8b0b-cb0a0c2fbc24.json
+++ b/Sample Data/rcbc-cycle-14/ballot_5dd8867c-ab05-446f-8b0b-cb0a0c2fbc24.json
@@ -1,0 +1,1 @@
+{"The Novice’s Tale - 240":5,"The Weary Blues - 128":4,"The Prestige - 404":1,"Anna Karenina - 864":3,"And Then There Were None - 272":2,"The Invincible - 200":6}

--- a/Sample Data/rcbc-cycle-14/ballot_67d54e50-398d-4ba2-8392-6eb0d0185231.json
+++ b/Sample Data/rcbc-cycle-14/ballot_67d54e50-398d-4ba2-8392-6eb0d0185231.json
@@ -1,0 +1,1 @@
+{"The Novice’s Tale - 240":5,"The Weary Blues - 128":1,"The Prestige - 404":2,"Anna Karenina - 864":4,"And Then There Were None - 272":3,"The Invincible - 200":6}

--- a/Sample Data/rcbc-cycle-14/ballot_8c3eaec6-d071-44f1-ad29-8f590ffa5314.json
+++ b/Sample Data/rcbc-cycle-14/ballot_8c3eaec6-d071-44f1-ad29-8f590ffa5314.json
@@ -1,0 +1,1 @@
+{"The Novice’s Tale - 240":6,"The Weary Blues - 128":4,"The Prestige - 404":5,"Anna Karenina - 864":2,"And Then There Were None - 272":1,"The Invincible - 200":3}

--- a/Sample Data/rcbc-cycle-14/ballot_fa1d9d17-9ae0-4a9e-85b3-ef82f40a8375.json
+++ b/Sample Data/rcbc-cycle-14/ballot_fa1d9d17-9ae0-4a9e-85b3-ef82f40a8375.json
@@ -1,0 +1,1 @@
+{"The Novice’s Tale - 240":4,"The Weary Blues - 128":2,"The Prestige - 404":5,"Anna Karenina - 864":3,"And Then There Were None - 272":6,"The Invincible - 200":1}

--- a/Sample Data/rcbc-cycle-14/config.json
+++ b/Sample Data/rcbc-cycle-14/config.json
@@ -1,0 +1,10 @@
+{
+  "unique_identifier": "rcbc-cycle-14",
+  "title": "rcbc-cycle-14",
+  "candidates": ["The Novice’s Tale - 240", "The Weary Blues - 128", "The Prestige - 404", "Anna Karenina - 864", "And Then There Were None - 272", "The Invincible - 200"],
+  "seats": 3,
+  "allow_incomplete": false,
+  "allow_ties": false,
+  "password_hash": "a97bc0e5a9ad34434cdd8a12bf7699319546e40efe8f9b01b48eb2071fdf8ab3",
+  "accepting_responses": true
+}

--- a/cpo_stv.R
+++ b/cpo_stv.R
@@ -516,7 +516,15 @@ cpo_stv <- function(df, seats = 3, normalize = TRUE, multi = FALSE,
     outcome_b <- outcomes[index_b,]
     
     relevant_candidates <- unique(c(outcome_a, outcome_b))
+    if (is.list(relevant_candidates)) {
+      relevant_candidates <- unlist(relevant_candidates)
+    }
+    relevant_candidates <- as.character(relevant_candidates)
     transfer_eligible <- intersect(outcome_a, outcome_b)
+    if (is.list(transfer_eligible)) {
+      transfer_eligible <- unlist(transfer_eligible)
+    }
+    transfer_eligible <- as.character(transfer_eligible)
     
     # Eliminate candidates in neither outcome
     votes <- ballots %>% select(all_of(relevant_candidates))


### PR DESCRIPTION
Fixes CPO-STV error on cycle 14 (and any elections where the outcomes matrix returns list-typed values instead of character vectors).

### The Bug

The `compare_matchup()` function in `cpo_stv.R` uses `outcomes[index,]` to extract candidate names for matchups. When the outcomes matrix is created via `cbind()` in the CPO-STV pipeline, indexing can return **lists** instead of character vectors. This causes:

- `all_of(relevant_candidates)` to fail with "Subscript must be numeric or character, not a list"
- `scores[transfer_eligible]` to fail with "invalid subscript type 'list'"

### The Fix

Coerce both `relevant_candidates` and `transfer_eligible` to character vectors after their creation, using `as.character()` (with a defensive `is.list()` check).

### Testing

Verified by running CPO-STV directly against cycle 14 data. Results:

```
Success!
Winners: And Then There Were None - 272, The Invincible - 200, The Prestige - 404
```