### PR TITLE
fix: guard cbind() to preserve outcomes matrix structure

### DIFF
--- a/cpo_stv.R
+++ b/cpo_stv.R
@@ -490,10 +490,12 @@ cpo_stv <- function(df, seats = 3, normalize = TRUE, multi = FALSE,
   )
   numoutcomes <- nrow(outcomes)
   # Then we add the first vote winners back in as columns
-  outcomes <- first_vote_winners %>% 
-    sapply(function (winner) rep(winner, numoutcomes)) %>%
-    unname() %>%
-    cbind(outcomes)
+  if (num_first_winners > 0) {
+    outcomes <- first_vote_winners %>% 
+      sapply(function (winner) rep(winner, numoutcomes)) %>%
+      unname() %>%
+      cbind(outcomes)
+  }
   
   # Find all possible pairs of outcomes
   matchups <- combinations(numoutcomes, 2)


### PR DESCRIPTION
## Summary

Fixes the root cause of the `all_of()` error in `compare_matchup()` by preventing the `cbind()` call from corrupting the `outcomes` matrix when there are no first-preference winners.

## The Bug

When `outcomes` has no first-preference winners, `sapply(character(0), ...)` returns an empty list. `cbind(list(), matrix)` then converts the entire `outcomes` object into a list structure, breaking subsequent `dplyr::all_of()` calls with:

```
! Can't subset elements. ✖ Subscript must be numeric or character, not a list.
```

This affected any CPO-STV election with no first-preference winners, not just those with first-preference winners (as initially thought).

## The Fix

Only run the `cbind()` block when `first_vote_winners` is non-empty:

```r
if (num_first_winners > 0) {
  outcomes <- first_vote_winners %>% 
    sapply(function (winner) rep(winner, numoutcomes)) %>%
    unname() %>%
    cbind(outcomes)
}
```

This keeps `outcomes` as a proper character matrix throughout the pipeline, eliminating the need for defensive `as.character()` coercion.

## Verification

Tested against cycle 14 (6 ballots, 6 candidates, 3 seats, no first-preference winners):

- **Before fix:** Error in `all_of()` — subscript must be numeric or character, not a list
- **After fix:** CPO-STV completes successfully in 0.727 seconds
- **Winners:** And Then There Were None - 272, The Invincible - 200, The Prestige - 404
- **No tiebreakers triggered**

## Related

Supersedes the type-coercion workaround in PR #53, which patched the symptom rather than the cause.